### PR TITLE
refact : handling error while inserting document into mongodb

### DIFF
--- a/collect/mongo.py
+++ b/collect/mongo.py
@@ -1,14 +1,21 @@
 from pymongo import MongoClient
 from config.config import MONGODB_CONFIG
 import datetime
+import traceback
 
 client = MongoClient(MONGODB_CONFIG['host'], MONGODB_CONFIG['port'])
 db = client[MONGODB_CONFIG['dbname']]
 
+
 def insert(collection_name, data):
     collection = db[collection_name]
     data['date'] = datetime.datetime.now()
-    collection.insert(data)
+    try:
+        collection.insert(data)
+    except Exception:
+        # duplicated docId
+        print('failed to insert document into mongo')
+        print(traceback.format_exc())
 
 
 def close():


### PR DESCRIPTION
refact : handling error while inserting document into mongodb

in mongodb,
removed duplicated documents using aggregation below
```
use blog_documents
db.getCollection('collection_name').aggregate([{$group:{_id:"$docId", dups:{$push:"$_id"}, count: {$sum: 1}}},
{$match:{count: {$gt: 1}}}
]).forEach(function(doc){
  doc.dups.shift();
  db.getCollection('collection_name').remove({_id : {$in: doc.dups}});
})
```
and created an index to prevent inserting duplicated documents anymore using unique property
```
db.getCollection('collection_name').createIndex( { docId: -1 }, { unique: true})
```
